### PR TITLE
前回階層違いのためもう一度tailwind関連

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+  def home
+  end
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,0 +1,5 @@
+<div class="text-center mt-20">
+  <h1 class="text-4xl font-bold mb-4">仮トップページ</h1>
+  <p class="text-gray-700 mb-6">このページが表示されれば root 設定成功です。</p>
+  <a href="#" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded">サンプルボタン</a>
+</div>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get home" do
+    get pages_home_url
+    assert_response :success
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
-    get pages_home_url
+    get root_url
     assert_response :success
   end
 end


### PR DESCRIPTION
## Tailwind導入 & 仮トップページ追加

### 概要

Tailwind CSS を導入し、アプリ全体のスタイル基盤を整えました。
ルート設定を行い、仮トップページを作成しました。

### 変更内容

- .gitignore
- Tailwind ビルド関連ファイルや node_modules を無視するよう修正
- Gemfile / Gemfile.lock
- cssbundling-rails の導入
- config/manifest.js
- //= link_tree ../builds を追記してビルド済みCSSを読み込むよう修正
- app/assets/stylesheets/application.css
- 削除（未処理の @import 残骸を除去）
- app/assets/stylesheets/application.tailwind.css
- 新規追加（@tailwind base; @tailwind components; @tailwind utilities;）
- app/javascript/tailwind/
- Tailwind 設定ファイル一式を追加
- app/views/layouts/application.html.erb
- CSSリンクを application → tailwind に変更
- config/routes.rb
- root を pages#home に設定
- app/controllers/pages_controller.rb
- 追加（仮トップページ表示用）
- app/views/pages/home.html.erb
- 追加（仮トップページのビュー）
- app/helpers/pages_helper.rb
- 追加（空）
- test/controllers/pages_controller_test.rb
- 追加（pages_controller用のテスト）
- bin/dev / Procfile.dev
- 開発サーバー起動用に追加

### 動作確認

- docker compose exec web bin/dev で開発サーバーを起動
- http://localhost:3000/ にアクセス
- 仮トップページが表示され、Tailwindのスタイルが適用されていることを確認

### 関連issue
- close #11