### PR TITLE
ルビーバージョン削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby '3.2.5'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2", ">= 7.2.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,8 +357,5 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
-RUBY VERSION
-   ruby 3.2.5p208
-
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
# プルリクエスト内容
gemfileよりルビーバージョン削除

## やったこと
- Gemfile から `ruby '3.2.5'` の指定を削除
- `.gitignore` に Docker 関連ファイルを追加（ローカル開発用で Heroku には不要のため）

## 背景・理由
- Heroku デプロイ時に Docker を使わない構成に戻すため
- 現状、ローカルでも Heroku でも Ruby 3.2 系で問題なく動作しているため、明示的にバージョンを固定する必要はなし

## 補足
- 以前、Docker 関連で中途半端な変更を行ったが、最終的に buildpack ベースでの Heroku デプロイで正常に動作することを確認済み
- この変更で main ブランチに直接コミットしているため、プルリクエストとしては Gemfile 修正のみが対象

## やったこと
- Gemfile から `ruby '3.2.5'` の指定を削除
- `.gitignore` に Docker 関連ファイルを追加（ローカル開発用で Heroku には不要のため）

## 背景・理由
- Heroku デプロイ時に Docker を使わない構成に戻すため
- 現状、ローカルでも Heroku でも Ruby 3.2 系で問題なく動作しているため、明示的にバージョンを固定する必要はなし

## 補足
- 以前、Docker 関連で中途半端な変更を行ったが、最終的に buildpack ベースでの Heroku デプロイで正常に動作することを確認済み
- この変更で main ブランチに直接コミットしているため、プルリクエストとしては Gemfile 修正のみが対象

##関連issue
close #23
