### PR TITLE
作品基本設定

### DIFF
--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  has_many :works
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :works, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,0 +1,9 @@
+class Work < ApplicationRecord
+  belongs_to :user
+  belongs_to :genre
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :genre_id, presence: true
+  validates :theme, length: { maximum: 50 }, allow_blank: true
+  validates :synopsis, length: { maximum: 1000 }, allow_blank: true
+end

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with(model: @work) do |f| %>
+  <div>
+    <%= f.label :title, "タイトル" %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :genre_id, "ジャンル" %>
+    <%= f.collection_select :genre_id, Genre.all, :id, :name, prompt: "ジャンルを選択してください" %>
+  </div>
+
+  <div>
+    <%= f.label :theme, "テーマ" %>
+    <%= f.text_field :theme %>
+  </div>
+
+  <div>
+    <%= f.label :synopsis, "あらすじ" %>
+    <%= f.text_area :synopsis %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/db/migrate/20250920232124_create_genres.rb
+++ b/db/migrate/20250920232124_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[7.2]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250920232200_create_works.rb
+++ b/db/migrate/20250920232200_create_works.rb
@@ -1,0 +1,13 @@
+class CreateWorks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :works do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :genre, null: false, foreign_key: true
+      t.string :title
+      t.string :theme
+      t.text :synopsis
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_15_134406) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_20_232200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -25,4 +31,19 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_15_134406) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  create_table "works", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "genre_id", null: false
+    t.string "title"
+    t.string "theme"
+    t.text "synopsis"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["genre_id"], name: "index_works_on_genre_id"
+    t.index ["user_id"], name: "index_works_on_user_id"
+  end
+
+  add_foreign_key "works", "genres"
+  add_foreign_key "works", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,7 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+genres = %w[ファンタジー ミステリー 恋愛 SF ホラー エッセイ 児童書・童話 BL その他]
+genres.each do |name|
+  Genre.find_or_create_by!(name: name)
+end

--- a/test/fixtures/genres.yml
+++ b/test/fixtures/genres.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/works.yml
+++ b/test/fixtures/works.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  genre: one
+  title: MyString
+  theme: MyString
+  synopsis: MyText
+
+two:
+  user: two
+  genre: two
+  title: MyString
+  theme: MyString
+  synopsis: MyText

--- a/test/models/genre_test.rb
+++ b/test/models/genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/work_test.rb
+++ b/test/models/work_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WorkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Work モデルを作成し、小説作品の基本設定を保存できる土台を実装しました。

## 実装内容
- Work モデル作成（タイトル・ジャンル・あらすじ・テーマ）
- バリデーション追加
  - タイトル：必須、最大100文字
  - ジャンル：必須
  - テーマ：最大50文字
  - あらすじ：最大1000文字
- Genre モデルを作成し、`seeds.rb` に固定ジャンルを定義
- Work モデルにジャンルを関連付け（belongs_to :genre）
- Work 登録時にジャンルをプルダウンから選択できるよう準備

## 関連issue
close #14 
close #15 

